### PR TITLE
Customizable encoder/decoder/client/errorDecoder etc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-core</artifactId>
       <version>${feign.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-httpclient</artifactId>
       <version>${feign.version}</version>
+    </dependency>    
+
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-slf4j</artifactId>
+      <version>${feign.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -14,6 +14,7 @@
 package com.github.ethancommitpush.feign;
 
 import com.github.ethancommitpush.feign.annotation.FeignClient;
+import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
 
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
@@ -36,6 +37,8 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.httpclient.ApacheHttpClient;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 
 import lombok.Getter;
 
@@ -64,28 +67,19 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
     @Bean
     @ConditionalOnMissingBean(name = "feignErrorDecoder")
     public ErrorDecoder feignErrorDecoder() {
-        return FeignConfigurationUtils.resolveErrorDecoder(
-            getBeanFactory(), 
-            getProperties().getDefaultErrorDecoderBean(), 
-            getProperties().getDefaultErrorDecoderClass());
+        return new CustomErrorDecoder();
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "feignDecoder")
-    public Decoder feignDecoder() {        
-        return FeignConfigurationUtils.resolveDecoder(
-            getBeanFactory(), 
-            getProperties().getDefaultDecoderBean(), 
-            getProperties().getDefaultDecoderClass());
+    public Decoder feignDecoder() {
+        return new JacksonDecoder();
     }
 
     @Bean
     @ConditionalOnMissingBean(name = "feignEncoder")
     public Encoder feignEncoder() {
-        return FeignConfigurationUtils.resolveEncoder(
-            getBeanFactory(), 
-            getProperties().getDefaultEncoderBean(), 
-            getProperties().getDefaultEncoderClass());
+        return new JacksonEncoder();
     }
 
     @Override
@@ -100,7 +94,7 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
     }
     /**
      * Get a default httpClient which trust self-signed certificates.
-     * 
+     *
      * @return default httpClient.
      */
     private CloseableHttpClient getHttpClient() {

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -13,7 +13,10 @@
  */
 package com.github.ethancommitpush.feign;
 
+import java.beans.BeanProperty;
+
 import com.github.ethancommitpush.feign.annotation.FeignClient;
+import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -23,6 +26,7 @@ import org.springframework.context.annotation.Import;
 
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 
@@ -35,8 +39,10 @@ import feign.jackson.JacksonEncoder;
 @Import(FeignClientsRegistrar.class)
 public class FeignClientsAutoConfiguration {
 
-    public FeignClientsAutoConfiguration() {
-        System.out.println("------------------------------- starter FeignClientsAutoConfiguration.ctor");
+    @Bean
+    @ConditionalOnMissingBean(ErrorDecoder.class)
+    public ErrorDecoder errorDecoder() {
+        return new CustomErrorDecoder();
     }
 
     @Bean

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -13,8 +13,6 @@
  */
 package com.github.ethancommitpush.feign;
 
-import java.beans.BeanProperty;
-
 import com.github.ethancommitpush.feign.annotation.FeignClient;
 import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
 

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -14,7 +14,6 @@
 package com.github.ethancommitpush.feign;
 
 import com.github.ethancommitpush.feign.annotation.FeignClient;
-import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -51,14 +50,17 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
     }
 
     @Bean
-    @ConditionalOnMissingBean(ErrorDecoder.class)
-    public ErrorDecoder errorDecoder() {
-        return new CustomErrorDecoder();
+    @ConditionalOnMissingBean(name = "feignErrorDecoder")
+    public ErrorDecoder feignErrorDecoder() {
+        return FeignConfigurationUtils.resolveErrorDecoder(
+            getBeanFactory(), 
+            getProperties().getDefaultErrorDecoderBean(), 
+            getProperties().getDefaultErrorDecoderClass());
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "defaultFeignDecoder")
-    public Decoder defaultFeignDecoder() {
+    @ConditionalOnMissingBean(name = "feignDecoder")
+    public Decoder feignDecoder() {
         System.out.println("------------------------starter decoder--------------------------->");
         
         return FeignConfigurationUtils.resolveDecoder(
@@ -68,8 +70,8 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "defaultFeignEncoder")
-    public Encoder defaultFeignEncoder() {
+    @ConditionalOnMissingBean(name = "feignEncoder")
+    public Encoder feignEncoder() {
         System.out.println("------------------------starter encoder--------------------------->");
 
         return FeignConfigurationUtils.resolveEncoder(

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -14,9 +14,17 @@
 package com.github.ethancommitpush.feign;
 
 import com.github.ethancommitpush.feign.annotation.FeignClient;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -26,4 +34,23 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnClass({ FeignClient.class })
 @Import(FeignClientsRegistrar.class)
 public class FeignClientsAutoConfiguration {
+
+    public FeignClientsAutoConfiguration() {
+        System.out.println("------------------------------- starter FeignClientsAutoConfiguration.ctor");
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Decoder.class)
+    public Decoder decoder() {
+        System.out.println("------------------------starter decoder--------------------------->");
+        return new JacksonDecoder();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Encoder.class)
+    public Encoder encoder() {
+        System.out.println("------------------------starter encoder--------------------------->");
+        return new JacksonEncoder();
+    }
+
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -56,7 +56,7 @@ public class FeignClientsAutoConfiguration {
     public Decoder defaultDecoder() {
         System.out.println("------------------------starter decoder--------------------------->");
         
-        Class<? extends Decoder> decoderClass = getProperties().getDecoderClass();
+        Class<? extends Decoder> decoderClass = getProperties().getDefaultDecoderClass();
 
         try {
             return (Decoder) decoderClass.newInstance();
@@ -70,7 +70,7 @@ public class FeignClientsAutoConfiguration {
     public Encoder defaultEncoder() {
         System.out.println("------------------------starter encoder--------------------------->");
 
-        Class<? extends Encoder> encoderClass = getProperties().getEncoderClass();
+        Class<? extends Encoder> encoderClass = getProperties().getDefaultEncoderClass();
         try {
             return (Encoder) encoderClass.newInstance();
         } catch (Exception e) {

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsAutoConfiguration.java
@@ -72,9 +72,7 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
 
     @Bean
     @ConditionalOnMissingBean(name = "feignDecoder")
-    public Decoder feignDecoder() {
-        System.out.println("------------------------starter decoder--------------------------->");
-        
+    public Decoder feignDecoder() {        
         return FeignConfigurationUtils.resolveDecoder(
             getBeanFactory(), 
             getProperties().getDefaultDecoderBean(), 
@@ -84,8 +82,6 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
     @Bean
     @ConditionalOnMissingBean(name = "feignEncoder")
     public Encoder feignEncoder() {
-        System.out.println("------------------------starter encoder--------------------------->");
-
         return FeignConfigurationUtils.resolveEncoder(
             getBeanFactory(), 
             getProperties().getDefaultEncoderBean(), 
@@ -100,7 +96,6 @@ public class FeignClientsAutoConfiguration implements BeanFactoryAware {
     @Bean
     @ConditionalOnMissingBean(name = "feignClient")
     public Client feignClient() {
-        System.out.println("------------------------starter feign client--------------------------->");
         return new ApacheHttpClient(getHttpClient());
     }
     /**

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -84,7 +84,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     private T feignBuild() {
         Feign.Builder builder = Feign.builder();
         
-        Client client = getFeignClient();
+        Client client = resolveClient();
         if (client != null) {
             builder.client(client);
         }
@@ -122,6 +122,25 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     @Override
     public Class<?> getObjectType() {
         return this.apiType;
+    }
+
+    /**
+     * Resolves the http client from either &#64;FeignClient annotation or default properties
+     * 
+     * @return client.
+     */
+    @SuppressWarnings("unchecked")
+    public Client resolveClient() {
+        Class<?> clientClass = (Class<?>) getAttributes().get("client");
+        String clientBeanName = (String) getAttributes().get("clientBean");
+
+        Client client = FeignConfigurationUtils.resolveClient(getBeanFactory(), clientBeanName,
+                (Class<? extends Client>) clientClass);
+        if (client != null) {
+            return client;
+        }
+
+        return getFeignClient();
     }
 
     /**

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -127,7 +127,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     /**
      * Resolves the http client from either &#64;FeignClient annotation or default properties
      * 
-     * @return client.
+     * @return client
      */
     @SuppressWarnings("unchecked")
     public Client resolveClient() {
@@ -144,9 +144,9 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     }
 
     /**
-     * Get the encoder value from the attributes of the &#64;FeignClient annotation.
+     * Resolves the encoder from either &#64;FeignClient annotation or default properties
      * 
-     * @return encoder.
+     * @return encoder
      */
     @SuppressWarnings("unchecked")
     public Encoder resolveEncoder() {
@@ -163,9 +163,9 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     }
 
     /**
-     * Get the decoder value from the attributes of the &#64;FeignClient annotation.
+     * Resolves the decoder from either &#64;FeignClient annotation or default properties
      * 
-     * @return decoder.
+     * @return decoder
      */
     @SuppressWarnings("unchecked")
     public Decoder resolveDecoder() {
@@ -182,9 +182,9 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     }
 
     /**
-     * Get the default error decoder value from the attributes of the &#64;FeignClient annotation.
+     * Resolves the error decoder from either &#64;FeignClient annotation or default properties
      * 
-     * @return decoder.
+     * @return error decoder
      */
     @SuppressWarnings("unchecked")
     public ErrorDecoder resolveErrorDecoder() {

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -67,11 +67,8 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     private Map<String, Object> attributes;
 
-    private final FeignClientsProperties properties;
-
-    public FeignClientsFactory(FeignClientsProperties properties) {
-        this.properties = properties;
-    }
+    @Autowired
+    private FeignClientsProperties properties;
 
     @Override
     public Object getObject() throws Exception {

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -30,9 +30,9 @@ import java.util.Map;
 @Getter
 @Setter
 @EnableConfigurationProperties(FeignClientsProperties.class)
-public class FeignClientsFactory implements FactoryBean<Object>, InitializingBean {
+public class FeignClientsFactory<T> implements FactoryBean<Object>, InitializingBean {
     
-    private Class<?> apiType;
+    private Class<T> apiType;
     
     private String url;
     
@@ -94,7 +94,7 @@ public class FeignClientsFactory implements FactoryBean<Object>, InitializingBea
      * @param logLevel log level.
      * @return generated feign client.
      */
-    private <T> T feignBuild(Class<T> apiType, String url, Encoder encoder, String logLevel) {
+    private T feignBuild() {
         Feign.Builder builder = Feign.builder().client(new ApacheHttpClient(getHttpClient()))
                 .encoder(getEncoder())
                 .decoder(getDecoder())

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -16,12 +16,14 @@ package com.github.ethancommitpush.feign;
 import feign.Client;
 import feign.Feign;
 import feign.Logger;
+import feign.Logger.Level;
 import feign.slf4j.Slf4jLogger;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -40,6 +42,7 @@ import java.util.Map;
  */
 @Getter
 @Setter
+@Slf4j
 @EnableConfigurationProperties(FeignClientsProperties.class)
 public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryAware, EnvironmentAware {
 
@@ -68,7 +71,9 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     @Override
     public Object getObject() throws Exception {
-        return feignBuild();
+        Object r = feignBuild();
+        log.debug("{} feign client: instance is {}, url is {}", getApiType(), r, getUrl());
+        return r;
     }
 
     /**
@@ -86,28 +91,35 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
         Feign.Builder builder = Feign.builder();
 
         Client client = resolveClient();
+        log.debug("{} feign client {}: http client is {}", getApiType(), client);
         if (client != null) {
             builder.client(client);
         }
 
         Encoder encoder = resolveEncoder();
+        log.debug("{} feign client {}: encoder is {}", getApiType(), encoder);
         if (encoder != null) {
             builder.encoder(encoder);
         }
 
         Decoder decoder = resolveDecoder();
+        log.debug("{} feign client {}: decoder is {}", getApiType(), decoder);
         if (decoder != null) {
             builder.decoder(decoder);
         }
 
         Logger logger = resolveLogger();
+        log.debug("{} feign client {}: logger is {}", getApiType(), logger);
         if (logger != null) {
             builder.logger(logger);
         }
 
-        builder.logLevel(getProperties().getLogLevel());
+        Level logLevel = getProperties().getLogLevel();
+        log.debug("{} feign client {}: logger level is {}", getApiType(), logLevel);
+        builder.logLevel(logLevel);
 
         ErrorDecoder errorDecoder = resolveErrorDecoder();
+        log.debug("{} feign client {}: error decoder is {}", getApiType(), errorDecoder);
         if (errorDecoder != null) {
             builder.errorDecoder(errorDecoder);
         }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -152,10 +152,6 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     @SuppressWarnings("unchecked")
     public Encoder resolveEncoder() {
         Class<?> encoderClass = (Class<?>) getAttributes().get("encoder");
-        if (encoderClass == void.class) {
-            encoderClass = null;
-        }
-
         String encoderBeanName = (String) getAttributes().get("encoderBean");
 
         Encoder encoder = FeignConfigurationUtils.resolveEncoder(getBeanFactory(), encoderBeanName,
@@ -175,10 +171,6 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     @SuppressWarnings("unchecked")
     public Decoder resolveDecoder() {
         Class<?> decoderClass = (Class<?>) getAttributes().get("decoder");
-        if (decoderClass == void.class) {
-            decoderClass = null;
-        }
-
         String decoderBeanName = (String) getAttributes().get("decoderBean");
 
         Decoder decoder = FeignConfigurationUtils.resolveDecoder(getBeanFactory(), decoderBeanName,
@@ -198,10 +190,6 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     @SuppressWarnings("unchecked")
     public ErrorDecoder resolveErrorDecoder() {
         Class<?> errorDecoderClass = (Class<?>) getAttributes().get("errorDecoder");
-        if (errorDecoderClass == void.class) {
-            errorDecoderClass = null;
-        }
-
         String errorDecoderBeanName = (String) getAttributes().get("errorDecoderBean");
 
         ErrorDecoder errorDecoder = FeignConfigurationUtils.resolveErrorDecoder(getBeanFactory(), errorDecoderBeanName,

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -17,6 +17,8 @@ import org.apache.http.ssl.SSLContexts;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
 import javax.net.ssl.SSLContext;
 
 import java.security.cert.X509Certificate;
@@ -26,6 +28,7 @@ import java.security.cert.X509Certificate;
  */
 @Getter
 @Setter
+@EnableConfigurationProperties(FeignClientsProperties.class)
 public class FeignClientsFactory implements FactoryBean<Object>, InitializingBean {
     
     private Class<?> apiType;
@@ -41,19 +44,23 @@ public class FeignClientsFactory implements FactoryBean<Object>, InitializingBea
     @Autowired
     private ErrorDecoder errorDecoder;
     
-    private String logLevel;
+    private final FeignClientsProperties properties;
+
+    public FeignClientsFactory(FeignClientsProperties properties) {
+        this.properties = properties;
+    }
 
     @Override
     public  void afterPropertiesSet() throws Exception {
         System.out.println("---------------------------------- apiType=" + apiType + ", url=" + url 
                 + ", errorDecoder=" + errorDecoder
                 + ", decoder=" + decoder
-                + ", encoder=" + encoder + ", logLevel=" + logLevel);
+                + ", encoder=" + encoder + ", logLevel=" + getProperties().getLogLevel());
     }
 
     @Override
     public Object getObject() throws Exception {
-        return feignBuild(apiType, url, encoder, logLevel);
+        return feignBuild(apiType, url, encoder, getProperties().getLogLevel());
     }
 
     /**

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -19,7 +19,6 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.httpclient.ApacheHttpClient;
-import feign.slf4j.Slf4jLogger;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -120,7 +119,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
             builder.decoder(decoder);
         }
 
-        Logger logger = resolveLogger();
+        Logger logger = FeignLoggerKind.resolve(getProperties().getLoggerKind(), getApiType());
         if (logger != null) {
             builder.logger(logger);
         }
@@ -139,16 +138,6 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     @Override
     public Class<?> getObjectType() {
         return this.apiType;
-    }
-
-    public Logger resolveLogger() {
-        switch(getProperties().getLoggerKind()) {
-            case SYSTEM_ERR: return new Logger.ErrorLogger();
-            case JUL: return new Logger.JavaLogger(getApiType());
-            case NO_OP: return new Logger.NoOpLogger();
-            case SLF4j: return new Slf4jLogger();
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -51,8 +51,6 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     private Class<T> apiType;
 
-    private String url;
-
     @Autowired
     private Encoder feignEncoder;
 
@@ -132,6 +130,10 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
         }
 
         return builder.target(getApiType(), getUrl());
+    }
+
+    public String getUrl() {
+        return (String)getAttributes().get("url");
     }
     
 

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -16,6 +16,7 @@ package com.github.ethancommitpush.feign;
 import feign.Client;
 import feign.Feign;
 import feign.Logger;
+import feign.slf4j.Slf4jLogger;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
@@ -35,7 +36,7 @@ import org.springframework.core.env.Environment;
 import java.util.Map;
 
 /**
- * 
+ *
  */
 @Getter
 @Setter
@@ -72,7 +73,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     /**
      * Generate feign client.
-     * 
+     *
      * @param apiType  class type of the interface which declared with
      *                 &#64;FeignClient.
      * @param url      url from the attributes of the &#64;FeignClient annotation.
@@ -83,7 +84,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
      */
     private T feignBuild() {
         Feign.Builder builder = Feign.builder();
-        
+
         Client client = resolveClient();
         if (client != null) {
             builder.client(client);
@@ -99,7 +100,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
             builder.decoder(decoder);
         }
 
-        Logger logger = FeignLoggerKind.resolve(getProperties().getLoggerKind(), getApiType());
+        Logger logger = resolveLogger();
         if (logger != null) {
             builder.logger(logger);
         }
@@ -114,10 +115,20 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
         return builder.target(getApiType(), getUrl());
     }
 
+    public Logger resolveLogger() {
+        switch(getProperties().getLoggerType()) {
+            case SYSTEM_ERR: return new Logger.ErrorLogger();
+            case JUL: return new Logger.JavaLogger(getApiType());
+            case NO_OP: return new Logger.NoOpLogger();
+            case SLF4j: return new Slf4jLogger(getApiType());
+        }
+        return null;
+    }
+
     public String getUrl() {
         return resolveAttribute((String)getAttributes().get("url"));
     }
-    
+
 
     @Override
     public Class<?> getObjectType() {
@@ -126,7 +137,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     /**
      * Resolves the http client from either &#64;FeignClient annotation or default properties
-     * 
+     *
      * @return client
      */
     @SuppressWarnings("unchecked")
@@ -145,7 +156,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     /**
      * Resolves the encoder from either &#64;FeignClient annotation or default properties
-     * 
+     *
      * @return encoder
      */
     @SuppressWarnings("unchecked")
@@ -164,7 +175,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     /**
      * Resolves the decoder from either &#64;FeignClient annotation or default properties
-     * 
+     *
      * @return decoder
      */
     @SuppressWarnings("unchecked")
@@ -183,7 +194,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
 
     /**
      * Resolves the error decoder from either &#64;FeignClient annotation or default properties
-     * 
+     *
      * @return error decoder
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.github.ethancommitpush.feign;
 
 import feign.Feign;

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -1,0 +1,101 @@
+package com.github.ethancommitpush.feign;
+
+import feign.Feign;
+import feign.Logger;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.httpclient.ApacheHttpClient;
+import lombok.Getter;
+import lombok.Setter;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import javax.net.ssl.SSLContext;
+
+import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
+
+import java.security.cert.X509Certificate;
+
+/**
+ * 
+ */
+@Getter
+@Setter
+public class FeignClientsFactory implements FactoryBean<Object>, InitializingBean {
+    
+    private Class<?> apiType;
+    
+    private String url;
+    
+    @Autowired 
+    private Encoder encoder;
+
+    @Autowired
+    private Decoder decoder;
+    
+    private String logLevel;
+
+    @Override
+    public  void afterPropertiesSet() throws Exception {
+        System.out.println("---------------------------------- apiType=" + apiType + ", url=" + url 
+                + ", decoder=" + decoder
+                + ", encoder=" + encoder + ", logLevel=" + logLevel);
+    }
+
+    @Override
+    public Object getObject() throws Exception {
+        return feignBuild(apiType, url, encoder, logLevel);
+    }
+
+    /**
+     * Get a default httpClient which trust self-signed certificates.
+     * 
+     * @return default httpClient.
+     */
+    private CloseableHttpClient getHttpClient() {
+        CloseableHttpClient httpClient = null;
+        try {
+            // To trust self-signed certificates
+            TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
+            SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
+            SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(sslContext);
+            httpClient = HttpClients.custom().setSSLSocketFactory(csf).build();
+        } catch (Exception e) {
+        }
+        return httpClient;
+    }
+
+    /**
+     * Generate feign client.
+     * 
+     * @param apiType  class type of the interface which declared with
+     *                 &#64;FeignClient.
+     * @param url      url from the attributes of the &#64;FeignClient annotation.
+     * @param encoder  encoder from the attributes of the &#64;FeignClient
+     *                 annotation.
+     * @param logLevel log level.
+     * @return generated feign client.
+     */
+    private <T> T feignBuild(Class<T> apiType, String url, Encoder encoder, String logLevel) {
+        Feign.Builder builder = Feign.builder().client(new ApacheHttpClient(getHttpClient()))
+                .errorDecoder(new CustomErrorDecoder())
+                .encoder(getEncoder())
+                .decoder(getDecoder())
+                .logger(new Logger.ErrorLogger())
+                .logLevel(Logger.Level.valueOf(logLevel));
+
+        return builder.target(apiType, url);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return this.apiType;
+    }
+
+}

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -33,6 +33,9 @@ import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.util.StringUtils;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
 
 import javax.net.ssl.SSLContext;
 
@@ -45,9 +48,11 @@ import java.util.Map;
 @Getter
 @Setter
 @EnableConfigurationProperties(FeignClientsProperties.class)
-public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryAware {
+public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryAware, EnvironmentAware {
 
     private BeanFactory beanFactory;
+
+    private Environment environment;
 
     private Class<T> apiType;
 
@@ -133,7 +138,7 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     }
 
     public String getUrl() {
-        return (String)getAttributes().get("url");
+        return resolveAttribute((String)getAttributes().get("url"));
     }
     
 
@@ -215,6 +220,26 @@ public class FeignClientsFactory<T> implements FactoryBean<Object>, BeanFactoryA
     @Override
     public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
         this.beanFactory = beanFactory;
+    }
+
+    /**
+     * Set the {@code Environment} that this component runs in.
+     * @see org.springframework.context.EnvironmentAware
+     */
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * Get the value or resolve placeholders to find the value configured at the property file.
+     * @return value.
+     */
+    public String resolveAttribute(String value) {
+        if (StringUtils.hasText(value)) {
+            return getEnvironment().resolvePlaceholders(value);
+        }
+        return value;
     }
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsFactory.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import javax.net.ssl.SSLContext;
 
 import java.security.cert.X509Certificate;
+import java.util.Map;
 
 /**
  * 
@@ -44,6 +45,8 @@ public class FeignClientsFactory implements FactoryBean<Object>, InitializingBea
     @Autowired
     private ErrorDecoder errorDecoder;
     
+    private Map<String, Object> attributes;
+    
     private final FeignClientsProperties properties;
 
     public FeignClientsFactory(FeignClientsProperties properties) {
@@ -54,8 +57,7 @@ public class FeignClientsFactory implements FactoryBean<Object>, InitializingBea
     public  void afterPropertiesSet() throws Exception {
         System.out.println("---------------------------------- apiType=" + apiType + ", url=" + url 
                 + ", errorDecoder=" + errorDecoder
-                + ", decoder=" + decoder
-                + ", encoder=" + encoder + ", logLevel=" + getProperties().getLogLevel());
+                + ", attributes="  + attributes
     }
 
     @Override

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -44,7 +44,7 @@ public class FeignClientsProperties {
      * 
      * Note:
      * 1) exclusive with property 'defaultDecoderBean'
-     * 2) override-able by FeignClient.decoderClass/decoderBean
+     * 2) override-able by FeignClient.decoder/decoderBean
      * 
      * @return decoder class
      */
@@ -56,7 +56,7 @@ public class FeignClientsProperties {
      * 
      * Note: 
      * 1) exclusive with property 'defaultEncoderBean'
-     * 2) override-able by FeignClient.encoderClass/encoderBean
+     * 2) override-able by FeignClient.encoder/encoderBean
      * 
      * @return encoder class
      */
@@ -68,9 +68,9 @@ public class FeignClientsProperties {
      * 
      * Note: 
      * 1) exclusive with property 'defaultEncoderBean'
-     * 2) override-able by FeignClient.encoderClass/encoderBean
+     * 2) override-able by FeignClient.encoder/encoderBean
      * 
-     * @return encoder bean
+     * @return encoder bean name
      */
     private String defaultEncoderBean;
 
@@ -80,9 +80,9 @@ public class FeignClientsProperties {
      * 
      * Note:
      * 1) exclusive with property 'defaultDecoderBean'
-     * 2) override-able by FeignClient.decoderClass/decoderBean
+     * 2) override-able by FeignClient.decoder/decoderBean
      * 
-     * @return decoder bean
+     * @return decoder bean name
      */
     private String defaultDecoderBean;
 
@@ -92,9 +92,9 @@ public class FeignClientsProperties {
      * 
      * Note:
      * 1) exclusive with property 'defaultErorrDecoderBean'
-     * 2) override-able by FeignClient.errorDecoderClass/errorDecoderBean
+     * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
      * 
-     * @return error decoder bean
+     * @return error decoder bean name
      */
     private String defaultErrorDecoderBean;
     
@@ -104,7 +104,7 @@ public class FeignClientsProperties {
      * 
      * Note:
      * 1) exclusive with property 'defaultErrorDecoderBean'
-     * 2) override-able by FeignClient.errorDecoderClass/errorDecoderBean
+     * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
      * 
      * @return decoder class
      */

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -20,8 +20,10 @@ import lombok.ToString;
 @ToString
 public class FeignClientsProperties {
 
-    private String logLevel = Logger.Level.BASIC.name();
-    
+    private Logger.Level logLevel = Logger.Level.BASIC;
+
+    private FeignLoggerKind loggerKind = FeignLoggerKind.SYSTEM_ERR;
+
     /**
      * Default decoder class. 
      * The decoder class must implement the class feign.codec.Decoder.

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -1,0 +1,18 @@
+package com.github.ethancommitpush.feign;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import feign.Logger;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ConfigurationProperties("feign")
+@Setter
+@Getter
+@ToString
+public class FeignClientsProperties {
+
+    private String logLevel = Logger.Level.BASIC.name();
+
+}

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -20,50 +20,50 @@ public class FeignClientsProperties {
     private String logLevel = Logger.Level.BASIC.name();
     
     /**
-     * Default decoder class for the specified Feign client interface, to decode parameters
-     * in certain way. The decoder class must implement the class feign.codec.Decoder.
+     * Default decoder class. 
+     * The decoder class must implement the class feign.codec.Decoder.
      * 
      * Note:
-     * 1) exclusive with property 'decoderBean'
+     * 1) exclusive with property 'defaultDecoderBean'
      * 2) override-able by FeignClient.decoderClass/decoderBean
      * 
-     * @return decoder class for the specified Feign client interface
+     * @return decoder class
      */
     private Class<? extends Decoder> defaultDecoderClass = JacksonDecoder.class;
 
     /**
-     * Default encoder class for the specified Feign client interface, to encode parameters
-     * in certain way. The encoder class must implement the class feign.codec.Encoder.
+     * Default encoder class.
+     * The encoder class must implement the class feign.codec.Encoder.
      * 
      * Note: 
-     * 1) exclusive with property 'encoderBean'
+     * 1) exclusive with property 'defaultEncoderBean'
      * 2) override-able by FeignClient.encoderClass/encoderBean
      * 
-     * @return encoder class for the specified Feign client interface
+     * @return encoder class
      */
     private Class<? extends Encoder> defaultEncoderClass = JacksonEncoder.class;
     
     /**
-     * Default encoder bean name for the specified Feign client interface, to encode parameters
-     * in certain way. The encoder bean class must implement the class feign.codec.Encoder.
+     * Default encoder bean name.
+     * The encoder bean class must implement the class feign.codec.Encoder.
      * 
      * Note: 
-     * 1) exclusive with property 'encoderBean'
+     * 1) exclusive with property 'defaultEncoderBean'
      * 2) override-able by FeignClient.encoderClass/encoderBean
      * 
-     * @return encoder bean for the specified Feign client interface
+     * @return encoder bean
      */
     private String defaultEncoderBean;
 
     /**
-     * Default encoder bean name for the specified Feign client interface, to decode parameters
-     * in certain way. The decoder bean class must implement the class feign.codec.Decoder.
+     * Default decoder bean name. 
+     * The decoder bean class must implement the class feign.codec.Decoder.
      * 
      * Note:
-     * 1) exclusive with property 'decoderBean'
+     * 1) exclusive with property 'defaultDecoderBean'
      * 2) override-able by FeignClient.decoderClass/decoderBean
      * 
-     * @return decoder bean for the specified Feign client interface
+     * @return decoder bean
      */
     private String defaultDecoderBean;
 

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -1,10 +1,13 @@
 package com.github.ethancommitpush.feign;
 
+import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import feign.Logger;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import lombok.Getter;
@@ -66,5 +69,29 @@ public class FeignClientsProperties {
      * @return decoder bean
      */
     private String defaultDecoderBean;
+
+    /**
+     * Default error decoder bean name. 
+     * The error decoder bean class must implement the class feign.codec.ErrorDecoder.
+     * 
+     * Note:
+     * 1) exclusive with property 'defaultErorrDecoderBean'
+     * 2) override-able by FeignClient.errorDecoderClass/errorDecoderBean
+     * 
+     * @return error decoder bean
+     */
+    private String defaultErrorDecoderBean;
+    
+    /**
+     * Default error decoder class. 
+     * The error decoder class must implement the class feign.codec.ErrorDecoder.
+     * 
+     * Note:
+     * 1) exclusive with property 'defaultErrorDecoderBean'
+     * 2) override-able by FeignClient.errorDecoderClass/errorDecoderBean
+     * 
+     * @return decoder class
+     */
+    private Class<? extends ErrorDecoder> defaultErrorDecoderClass = CustomErrorDecoder.class;
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -36,12 +36,12 @@ public class FeignClientsProperties {
 
     private Logger.Level logLevel = Logger.Level.BASIC;
 
-    private FeignLoggerKind loggerKind = FeignLoggerKind.SYSTEM_ERR;
+    private FeignLoggerType loggerType = FeignLoggerType.SYSTEM_ERR;
 
     /**
-     * Default decoder class. 
+     * Default decoder class.
      * The decoder class must implement the class feign.codec.Decoder.
-     * 
+     *
      * Note:
      * 1) exclusive with property 'defaultDecoderBean'
      * 2) override-able by FeignClient.decoder/decoderBean
@@ -51,27 +51,27 @@ public class FeignClientsProperties {
     /**
      * Default encoder class.
      * The encoder class must implement the class feign.codec.Encoder.
-     * 
-     * Note: 
+     *
+     * Note:
      * 1) exclusive with property 'defaultEncoderBean'
      * 2) override-able by FeignClient.encoder/encoderBean
      */
     private Class<? extends Encoder> defaultEncoderClass = JacksonEncoder.class;
-    
+
     /**
      * Default encoder bean name.
      * The encoder bean class must implement the class feign.codec.Encoder.
-     * 
-     * Note: 
+     *
+     * Note:
      * 1) exclusive with property 'defaultEncoder'
      * 2) override-able by FeignClient.encoder/encoderBean
      */
     private String defaultEncoderBean;
 
     /**
-     * Default decoder bean name. 
+     * Default decoder bean name.
      * The decoder bean class must implement the class feign.codec.Decoder.
-     * 
+     *
      * Note:
      * 1) exclusive with property 'defaultDecoder'
      * 2) override-able by FeignClient.decoder/decoderBean
@@ -79,19 +79,19 @@ public class FeignClientsProperties {
     private String defaultDecoderBean;
 
     /**
-     * Default error decoder bean name. 
+     * Default error decoder bean name.
      * The error decoder bean class must implement the class feign.codec.ErrorDecoder.
-     * 
+     *
      * Note:
      * 1) exclusive with property 'defaultErorrDecoder'
      * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
      */
     private String defaultErrorDecoderBean;
-    
+
     /**
-     * Default error decoder class. 
+     * Default error decoder class.
      * The error decoder class must implement the class feign.codec.ErrorDecoder.
-     * 
+     *
      * Note:
      * 1) exclusive with property 'defaultErrorDecoder'
      * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
@@ -101,18 +101,18 @@ public class FeignClientsProperties {
     /**
      * Default http client class.
      * The client class must implement the class feign.Client.
-     * 
-     * Note: 
+     *
+     * Note:
      * 1) exclusive with property 'defaultClientBean'
      * 2) override-able by FeignClient.client/clientBean
      */
     private Class<Client> defaultClientClass;
-    
+
     /**
      * Default client bean name.
      * The cilent bean class must implement the class feign.Client.
-     * 
-     * Note: 
+     *
+     * Note:
      * 1) exclusive with property 'defaultClientBean'
      * 2) override-able by FeignClient.client/clientBean
      */

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.github.ethancommitpush.feign;
 
 import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -17,6 +17,7 @@ import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import feign.Client;
 import feign.Logger;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
@@ -108,5 +109,29 @@ public class FeignClientsProperties {
      * @return decoder class
      */
     private Class<? extends ErrorDecoder> defaultErrorDecoderClass = CustomErrorDecoder.class;
+
+    /**
+     * Default http client class.
+     * The client class must implement the class feign.Client.
+     * 
+     * Note: 
+     * 1) exclusive with property 'defaultClientBean'
+     * 2) override-able by FeignClient.client/clientBean
+     * 
+     * @return client class
+     */
+    private Class<Client> defaultClientClass;
+    
+    /**
+     * Default client bean name.
+     * The cilent bean class must implement the class feign.Client.
+     * 
+     * Note: 
+     * 1) exclusive with property 'defaultClientBean'
+     * 2) override-able by FeignClient.client/clientBean
+     * 
+     * @return client bean name
+     */
+    private String defaultClientBean;
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -45,8 +45,6 @@ public class FeignClientsProperties {
      * Note:
      * 1) exclusive with property 'defaultDecoderBean'
      * 2) override-able by FeignClient.decoder/decoderBean
-     * 
-     * @return decoder class
      */
     private Class<? extends Decoder> defaultDecoderClass = JacksonDecoder.class;
 
@@ -57,8 +55,6 @@ public class FeignClientsProperties {
      * Note: 
      * 1) exclusive with property 'defaultEncoderBean'
      * 2) override-able by FeignClient.encoder/encoderBean
-     * 
-     * @return encoder class
      */
     private Class<? extends Encoder> defaultEncoderClass = JacksonEncoder.class;
     
@@ -67,10 +63,8 @@ public class FeignClientsProperties {
      * The encoder bean class must implement the class feign.codec.Encoder.
      * 
      * Note: 
-     * 1) exclusive with property 'defaultEncoderBean'
+     * 1) exclusive with property 'defaultEncoder'
      * 2) override-able by FeignClient.encoder/encoderBean
-     * 
-     * @return encoder bean name
      */
     private String defaultEncoderBean;
 
@@ -79,10 +73,8 @@ public class FeignClientsProperties {
      * The decoder bean class must implement the class feign.codec.Decoder.
      * 
      * Note:
-     * 1) exclusive with property 'defaultDecoderBean'
+     * 1) exclusive with property 'defaultDecoder'
      * 2) override-able by FeignClient.decoder/decoderBean
-     * 
-     * @return decoder bean name
      */
     private String defaultDecoderBean;
 
@@ -91,10 +83,8 @@ public class FeignClientsProperties {
      * The error decoder bean class must implement the class feign.codec.ErrorDecoder.
      * 
      * Note:
-     * 1) exclusive with property 'defaultErorrDecoderBean'
+     * 1) exclusive with property 'defaultErorrDecoder'
      * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
-     * 
-     * @return error decoder bean name
      */
     private String defaultErrorDecoderBean;
     
@@ -103,10 +93,8 @@ public class FeignClientsProperties {
      * The error decoder class must implement the class feign.codec.ErrorDecoder.
      * 
      * Note:
-     * 1) exclusive with property 'defaultErrorDecoderBean'
+     * 1) exclusive with property 'defaultErrorDecoder'
      * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
-     * 
-     * @return decoder class
      */
     private Class<? extends ErrorDecoder> defaultErrorDecoderClass = CustomErrorDecoder.class;
 
@@ -117,8 +105,6 @@ public class FeignClientsProperties {
      * Note: 
      * 1) exclusive with property 'defaultClientBean'
      * 2) override-able by FeignClient.client/clientBean
-     * 
-     * @return client class
      */
     private Class<Client> defaultClientClass;
     
@@ -129,8 +115,6 @@ public class FeignClientsProperties {
      * Note: 
      * 1) exclusive with property 'defaultClientBean'
      * 2) override-able by FeignClient.client/clientBean
-     * 
-     * @return client bean name
      */
     private String defaultClientBean;
 

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -13,17 +13,10 @@
  */
 package com.github.ethancommitpush.feign;
 
-import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import feign.Client;
 import feign.Logger;
-import feign.codec.Decoder;
-import feign.codec.Encoder;
-import feign.codec.ErrorDecoder;
-import feign.jackson.JacksonDecoder;
-import feign.jackson.JacksonEncoder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -37,85 +30,5 @@ public class FeignClientsProperties {
     private Logger.Level logLevel = Logger.Level.BASIC;
 
     private FeignLoggerType loggerType = FeignLoggerType.SYSTEM_ERR;
-
-    /**
-     * Default decoder class.
-     * The decoder class must implement the class feign.codec.Decoder.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultDecoderBean'
-     * 2) override-able by FeignClient.decoder/decoderBean
-     */
-    private Class<? extends Decoder> defaultDecoderClass = JacksonDecoder.class;
-
-    /**
-     * Default encoder class.
-     * The encoder class must implement the class feign.codec.Encoder.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultEncoderBean'
-     * 2) override-able by FeignClient.encoder/encoderBean
-     */
-    private Class<? extends Encoder> defaultEncoderClass = JacksonEncoder.class;
-
-    /**
-     * Default encoder bean name.
-     * The encoder bean class must implement the class feign.codec.Encoder.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultEncoder'
-     * 2) override-able by FeignClient.encoder/encoderBean
-     */
-    private String defaultEncoderBean;
-
-    /**
-     * Default decoder bean name.
-     * The decoder bean class must implement the class feign.codec.Decoder.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultDecoder'
-     * 2) override-able by FeignClient.decoder/decoderBean
-     */
-    private String defaultDecoderBean;
-
-    /**
-     * Default error decoder bean name.
-     * The error decoder bean class must implement the class feign.codec.ErrorDecoder.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultErorrDecoder'
-     * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
-     */
-    private String defaultErrorDecoderBean;
-
-    /**
-     * Default error decoder class.
-     * The error decoder class must implement the class feign.codec.ErrorDecoder.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultErrorDecoder'
-     * 2) override-able by FeignClient.errorDecoder/errorDecoderBean
-     */
-    private Class<? extends ErrorDecoder> defaultErrorDecoderClass = CustomErrorDecoder.class;
-
-    /**
-     * Default http client class.
-     * The client class must implement the class feign.Client.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultClientBean'
-     * 2) override-able by FeignClient.client/clientBean
-     */
-    private Class<Client> defaultClientClass;
-
-    /**
-     * Default client bean name.
-     * The cilent bean class must implement the class feign.Client.
-     *
-     * Note:
-     * 1) exclusive with property 'defaultClientBean'
-     * 2) override-able by FeignClient.client/clientBean
-     */
-    private String defaultClientBean;
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -19,8 +19,8 @@ public class FeignClientsProperties {
 
     private String logLevel = Logger.Level.BASIC.name();
 
-    private Class<? extends Decoder> decoderClass = JacksonDecoder.class;
+    private Class<? extends Decoder> defaultDecoderClass = JacksonDecoder.class;
 
-    private Class<? extends Encoder> encoderClass = JacksonEncoder.class;
+    private Class<? extends Encoder> defaultEncoderClass = JacksonEncoder.class;
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -18,9 +18,53 @@ import lombok.ToString;
 public class FeignClientsProperties {
 
     private String logLevel = Logger.Level.BASIC.name();
-
+    
+    /**
+     * Default decoder class for the specified Feign client interface, to decode parameters
+     * in certain way. The decoder class must implement the class feign.codec.Decoder.
+     * 
+     * Note:
+     * 1) exclusive with property 'decoderBean'
+     * 2) override-able by FeignClient.decoderClass/decoderBean
+     * 
+     * @return decoder class for the specified Feign client interface
+     */
     private Class<? extends Decoder> defaultDecoderClass = JacksonDecoder.class;
 
+    /**
+     * Default encoder class for the specified Feign client interface, to encode parameters
+     * in certain way. The encoder class must implement the class feign.codec.Encoder.
+     * 
+     * Note: 
+     * 1) exclusive with property 'encoderBean'
+     * 2) override-able by FeignClient.encoderClass/encoderBean
+     * 
+     * @return encoder class for the specified Feign client interface
+     */
     private Class<? extends Encoder> defaultEncoderClass = JacksonEncoder.class;
+    
+    /**
+     * Default encoder bean name for the specified Feign client interface, to encode parameters
+     * in certain way. The encoder bean class must implement the class feign.codec.Encoder.
+     * 
+     * Note: 
+     * 1) exclusive with property 'encoderBean'
+     * 2) override-able by FeignClient.encoderClass/encoderBean
+     * 
+     * @return encoder bean for the specified Feign client interface
+     */
+    private String defaultEncoderBean;
+
+    /**
+     * Default encoder bean name for the specified Feign client interface, to decode parameters
+     * in certain way. The decoder bean class must implement the class feign.codec.Decoder.
+     * 
+     * Note:
+     * 1) exclusive with property 'decoderBean'
+     * 2) override-able by FeignClient.decoderClass/decoderBean
+     * 
+     * @return decoder bean for the specified Feign client interface
+     */
+    private String defaultDecoderBean;
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsProperties.java
@@ -3,6 +3,10 @@ package com.github.ethancommitpush.feign;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import feign.Logger;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -14,5 +18,9 @@ import lombok.ToString;
 public class FeignClientsProperties {
 
     private String logLevel = Logger.Level.BASIC.name();
+
+    private Class<? extends Decoder> decoderClass = JacksonDecoder.class;
+
+    private Class<? extends Encoder> encoderClass = JacksonEncoder.class;
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -111,8 +111,6 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 
 		definition.addPropertyValue("apiType", apiType);
         definition.addPropertyValue("url", url);
-		//definition.addPropertyValue("encoder", encoder);
-		//definition.addPropertyValue("decoder", decoder);
 		definition.addPropertyValue("logLevel", logLevel);
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -32,12 +32,15 @@ import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.ClassUtils;
 
+import lombok.Getter;
+
 import java.beans.Introspector;
 import java.util.*;
 
 /**
  * Registrar to register {@link com.github.ethancommitpush.feign.annotation.FeignClient}s.
  */
+@Getter
 public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoaderAware, EnvironmentAware {
 
     private static final String BASE_PACKAGES_KEY = "feign.base-packages";
@@ -61,11 +64,11 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
      */
     public void registerFeignClients(BeanDefinitionRegistry registry) {
         ClassPathScanningCandidateComponentProvider scanner = getScanner();
-        scanner.setResourceLoader(this.resourceLoader);
+        scanner.setResourceLoader(getResourceLoader());
 
         AnnotationTypeFilter annotationTypeFilter = new AnnotationTypeFilter(FeignClient.class);
         scanner.addIncludeFilter(annotationTypeFilter);
-        List<String> basePackages = Optional.ofNullable(environment.getProperty(BASE_PACKAGES_KEY))
+        List<String> basePackages = Optional.ofNullable(getEnvironment().getProperty(BASE_PACKAGES_KEY))
                 .map(s -> Arrays.asList(s.split("\\,"))).orElse(Collections.emptyList());
 
         basePackages.stream()
@@ -116,7 +119,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
      * @return scanner.
      */
     private ClassPathScanningCandidateComponentProvider getScanner() {
-        return new ClassPathScanningCandidateComponentProvider(false, this.environment) {
+        return new ClassPathScanningCandidateComponentProvider(false, getEnvironment()) {
             @Override
             protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
                 if (!beanDefinition.getMetadata().isIndependent()) {

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -93,8 +93,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
     private void registerFeignClient(BeanDefinitionRegistry registry, String className, Map<String, Object> attributes) {
         String shortClassName = ClassUtils.getShortName(className);
         String beanName =  Introspector.decapitalize(shortClassName);
-        //Encoder encoder = getEncoder(attributes);
-        //Decoder decoder = getDecoder(attributes);
+        
         Class<?> apiType = null;
         try {
             apiType = Class.forName(className);
@@ -116,42 +115,6 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 
 		BeanDefinitionHolder holder = new BeanDefinitionHolder(beanDefinition, beanName);
 		BeanDefinitionReaderUtils.registerBeanDefinition(holder, registry);
-    }
-
-    /**
-     * Get the encoder value from the attributes of the &#64;FeignClient annotation.
-     * 
-     * @return encoder.
-     */
-    private Encoder getEncoder(Map<String, Object> attributes) {
-        if (attributes.get("encoder") == null) {
-            return null;
-        }
-
-        Encoder encoder = null;
-        try {
-            encoder = (Encoder) ((Class<?>) attributes.get("encoder")).newInstance();
-        } catch (Exception e) {
-        }
-        return encoder;
-    }
-
-    /**
-     * Get the decoder value from the attributes of the &#64;FeignClient annotation.
-     * 
-     * @return decoder.
-     */
-    private Decoder getDecoder(Map<String, Object> attributes) {
-        if (attributes.get("decoder") == null) {
-            return null;
-        }
-
-        Decoder decoder = null;
-        try {
-            decoder = (Decoder) ((Class<?>) attributes.get("decoder")).newInstance();
-        } catch (Exception e) {
-        }
-        return decoder;
     }
 
     /**

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -99,12 +99,9 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 
         }
 
-        String url = resolve((String) attributes.get("url"));
-
         BeanDefinitionBuilder definition = BeanDefinitionBuilder.genericBeanDefinition(FeignClientsFactory.class);
 
 		definition.addPropertyValue("apiType", apiType);
-        definition.addPropertyValue("url", url);
         definition.addPropertyValue("attributes", attributes);
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_NAME);
 

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -14,8 +14,6 @@
 package com.github.ethancommitpush.feign;
 
 import com.github.ethancommitpush.feign.annotation.FeignClient;
-import feign.codec.Decoder;
-import feign.codec.Encoder;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -14,9 +14,9 @@
 package com.github.ethancommitpush.feign;
 
 import com.github.ethancommitpush.feign.annotation.FeignClient;
-import feign.Logger;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -44,7 +44,6 @@ import java.util.*;
 public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoaderAware, EnvironmentAware {
 
     private static final String BASE_PACKAGES_KEY = "feign.base-packages";
-    private static final String LOG_LEVEL_KEY = "feign.log-level";
 
     private Environment environment;
     private ResourceLoader resourceLoader;
@@ -71,8 +70,6 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
         scanner.addIncludeFilter(annotationTypeFilter);
         List<String> basePackages = Optional.ofNullable(environment.getProperty(BASE_PACKAGES_KEY))
                 .map(s -> Arrays.asList(s.split("\\,"))).orElse(Collections.emptyList());
-        String logLevel = Optional.ofNullable(environment.getProperty(LOG_LEVEL_KEY))
-                .orElse(Logger.Level.BASIC.name());
 
         basePackages.stream()
                 .map(p -> scanner.findCandidateComponents(p))
@@ -83,7 +80,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
                 .filter(meta -> meta.isInterface())
                 .forEach(meta -> {
                     Map<String, Object> attributes = meta.getAnnotationAttributes(FeignClient.class.getCanonicalName());
-                    registerFeignClient(registry, meta.getClassName(), attributes, logLevel);
+                    registerFeignClient(registry, meta.getClassName(), attributes);
                 });
     }
 
@@ -93,7 +90,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
      * @param attributes attributes of the &#64;FeignClient annotation.
      * @param logLevel log level configured at property file or as default value: BASIC.
      */
-    private void registerFeignClient(BeanDefinitionRegistry registry, String className, Map<String, Object> attributes, String logLevel) {
+    private void registerFeignClient(BeanDefinitionRegistry registry, String className, Map<String, Object> attributes) {
         String shortClassName = ClassUtils.getShortName(className);
         String beanName =  Introspector.decapitalize(shortClassName);
         //Encoder encoder = getEncoder(attributes);
@@ -111,7 +108,6 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 
 		definition.addPropertyValue("apiType", apiType);
         definition.addPropertyValue("url", url);
-		definition.addPropertyValue("logLevel", logLevel);
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 
 		AbstractBeanDefinition beanDefinition = definition.getBeanDefinition();

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -108,6 +108,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 
 		definition.addPropertyValue("apiType", apiType);
         definition.addPropertyValue("url", url);
+        definition.addPropertyValue("attributes", attributes);
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 
 		AbstractBeanDefinition beanDefinition = definition.getBeanDefinition();

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -31,7 +31,6 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.StringUtils;
 
 import java.beans.Introspector;
 import java.util.*;
@@ -110,17 +109,6 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 
 		BeanDefinitionHolder holder = new BeanDefinitionHolder(beanDefinition, beanName);
 		BeanDefinitionReaderUtils.registerBeanDefinition(holder, registry);
-    }
-
-    /**
-     * Get the value or resolve placeholders to find the value configured at the property file.
-     * @return value.
-     */
-    private String resolve(String value) {
-        if (StringUtils.hasText(value)) {
-            return this.environment.resolvePlaceholders(value);
-        }
-        return value;
     }
 
     /**

--- a/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignClientsRegistrar.java
@@ -106,7 +106,7 @@ public class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, Res
 		definition.addPropertyValue("apiType", apiType);
         definition.addPropertyValue("url", url);
         definition.addPropertyValue("attributes", attributes);
-		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
+		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_NAME);
 
 		AbstractBeanDefinition beanDefinition = definition.getBeanDefinition();
 		beanDefinition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, className);

--- a/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
@@ -16,6 +16,7 @@ package com.github.ethancommitpush.feign;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.util.StringUtils;
 
+import feign.Client;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
@@ -61,6 +62,11 @@ public class FeignConfigurationUtils {
     public static ErrorDecoder resolveErrorDecoder(BeanFactory beanFactory, String errorDecoderBeanName,
             Class<? extends ErrorDecoder> errorDecoderClass) {
         return resolveOverrideableBean(ErrorDecoder.class, beanFactory, errorDecoderBeanName, errorDecoderClass);
+    }
+
+    public static Client resolveClient(BeanFactory beanFactory, String clientBeanName,
+            Class<? extends Client> clientClass) {
+        return resolveOverrideableBean(Client.class, beanFactory, clientBeanName, clientClass);
     }
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
@@ -21,22 +21,23 @@ import feign.codec.Encoder;
 
 public class FeignConfigurationUtils {
 
-    public static Decoder resolveDecoder(BeanFactory beanFactory, String decoderBeanName,
-            Class<? extends Decoder> decoderClass) {
-        boolean hasBeanName = !StringUtils.isEmpty(decoderBeanName);
-        boolean hasClass = (decoderClass != null);
+    public static <T> T resolveOverrideableBean(Class<T> hint, BeanFactory beanFactory, String beanName,
+            Class<? extends T> beanClass) {
+        boolean hasBeanName = !StringUtils.isEmpty(beanName);
+        boolean hasClass = (beanClass != null);
 
         if (hasBeanName && hasClass) {
-            throw new IllegalArgumentException("feign client decoder bean is exclusive with decoder class");
+            throw new IllegalArgumentException(
+                String.format("feign client %s bean is exclusive with %s class", hint.getSimpleName(), hint.getSimpleName());
         }
 
         if (hasBeanName) {
-            return beanFactory.getBean(decoderBeanName, Decoder.class);
+            return beanFactory.getBean(beanName, hint);
         }
 
         if (hasClass) {
             try {
-                return (Decoder) decoderClass.getDeclaredConstructor().newInstance();
+                return (T) beanClass.getDeclaredConstructor().newInstance();
             } catch (ReflectiveOperationException e) {
                 throw new IllegalArgumentException(e);
             }
@@ -45,28 +46,14 @@ public class FeignConfigurationUtils {
         return null;
     }
 
+    public static Decoder resolveDecoder(BeanFactory beanFactory, String decoderBeanName,
+            Class<? extends Decoder> decoderClass) {
+        return resolveOverrideableBean(Decoder.class, beanFactory, decoderBeanName, decoderClass);
+    }
+
     public static Encoder resolveEncoder(BeanFactory beanFactory, String encoderBeanName,
             Class<? extends Encoder> encoderClass) {
-        boolean hasBeanName = !StringUtils.isEmpty(encoderBeanName);
-        boolean hasClass = (encoderClass != null);
-
-        if (hasBeanName && hasClass) {
-            throw new IllegalArgumentException("feign client encoder bean is exclusive with encoder class");
-        }
-
-        if (hasBeanName) {
-            return beanFactory.getBean(encoderBeanName, Encoder.class);
-        }
-
-        if (hasClass) {
-            try {
-                return (Encoder) encoderClass.getDeclaredConstructor().newInstance();
-            } catch (ReflectiveOperationException e) {
-                throw new IllegalArgumentException(e);
-            }
-        }
-
-        return null;
+        return resolveOverrideableBean(Encoder.class, beanFactory, encoderBeanName, encoderClass);
     }
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
@@ -22,10 +22,11 @@ import feign.codec.ErrorDecoder;
 
 public class FeignConfigurationUtils {
 
+    @SuppressWarnings("unchecked")
     public static <T> T resolveOverrideableBean(Class<T> hint, BeanFactory beanFactory, String beanName,
-            Class<? extends T> beanClass) {
+            Class<?> beanClass) {
         boolean hasBeanName = !StringUtils.isEmpty(beanName);
-        boolean hasClass = (beanClass != null);
+        boolean hasClass = (beanClass != null && beanClass != void.class);
 
         if (hasBeanName && hasClass) {
             throw new IllegalArgumentException(

--- a/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.ethancommitpush.feign;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.util.StringUtils;
+
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+
+public class FeignConfigurationUtils {
+
+    public static Decoder resolveDecoder(BeanFactory beanFactory, String decoderBeanName,
+            Class<? extends Decoder> decoderClass) {
+        boolean hasBeanName = !StringUtils.isEmpty(decoderBeanName);
+        boolean hasClass = (decoderClass != null);
+
+        if (hasBeanName && hasClass) {
+            throw new IllegalArgumentException("feign client decoder bean is exclusive with decoder class");
+        }
+
+        if (hasBeanName) {
+            return beanFactory.getBean(decoderBeanName, Decoder.class);
+        }
+
+        if (hasClass) {
+            try {
+                return (Decoder) decoderClass.getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        return null;
+    }
+
+    public static Encoder resolveEncoder(BeanFactory beanFactory, String encoderBeanName,
+            Class<? extends Encoder> encoderClass) {
+        boolean hasBeanName = !StringUtils.isEmpty(encoderBeanName);
+        boolean hasClass = (encoderClass != null);
+
+        if (hasBeanName && hasClass) {
+            throw new IllegalArgumentException("feign client encoder bean is exclusive with encoder class");
+        }
+
+        if (hasBeanName) {
+            return beanFactory.getBean(encoderBeanName, Encoder.class);
+        }
+
+        if (hasClass) {
+            try {
+                return (Encoder) encoderClass.getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignConfigurationUtils.java
@@ -18,6 +18,7 @@ import org.springframework.util.StringUtils;
 
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
 
 public class FeignConfigurationUtils {
 
@@ -28,7 +29,7 @@ public class FeignConfigurationUtils {
 
         if (hasBeanName && hasClass) {
             throw new IllegalArgumentException(
-                String.format("feign client %s bean is exclusive with %s class", hint.getSimpleName(), hint.getSimpleName());
+                String.format("feign client %s bean is exclusive with %s class", hint.getSimpleName(), hint.getSimpleName()));
         }
 
         if (hasBeanName) {
@@ -54,6 +55,11 @@ public class FeignConfigurationUtils {
     public static Encoder resolveEncoder(BeanFactory beanFactory, String encoderBeanName,
             Class<? extends Encoder> encoderClass) {
         return resolveOverrideableBean(Encoder.class, beanFactory, encoderBeanName, encoderClass);
+    }
+
+    public static ErrorDecoder resolveErrorDecoder(BeanFactory beanFactory, String errorDecoderBeanName,
+            Class<? extends ErrorDecoder> errorDecoderClass) {
+        return resolveOverrideableBean(ErrorDecoder.class, beanFactory, errorDecoderBeanName, errorDecoderClass);
     }
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignLoggerKind.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignLoggerKind.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.ethancommitpush.feign;
+
+public enum FeignLoggerKind {
+    
+    SYSTEM_ERR,
+    JUL,
+    NO_OP,
+    SLF4j;
+}

--- a/src/main/java/com/github/ethancommitpush/feign/FeignLoggerKind.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignLoggerKind.java
@@ -13,10 +13,23 @@
  */
 package com.github.ethancommitpush.feign;
 
+import feign.Logger;
+import feign.slf4j.Slf4jLogger;
+
 public enum FeignLoggerKind {
     
     SYSTEM_ERR,
     JUL,
     NO_OP,
     SLF4j;
+
+    public static Logger resolve(FeignLoggerKind kind, Class<?> apiType) {
+        switch(kind) {
+            case SYSTEM_ERR: return new Logger.ErrorLogger();
+            case JUL: return new Logger.JavaLogger(apiType);
+            case NO_OP: return new Logger.NoOpLogger();
+            case SLF4j: return new Slf4jLogger();
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/github/ethancommitpush/feign/FeignLoggerType.java
+++ b/src/main/java/com/github/ethancommitpush/feign/FeignLoggerType.java
@@ -13,23 +13,10 @@
  */
 package com.github.ethancommitpush.feign;
 
-import feign.Logger;
-import feign.slf4j.Slf4jLogger;
+public enum FeignLoggerType {
 
-public enum FeignLoggerKind {
-    
     SYSTEM_ERR,
     JUL,
     NO_OP,
     SLF4j;
-
-    public static Logger resolve(FeignLoggerKind kind, Class<?> apiType) {
-        switch(kind) {
-            case SYSTEM_ERR: return new Logger.ErrorLogger();
-            case JUL: return new Logger.JavaLogger(apiType);
-            case NO_OP: return new Logger.NoOpLogger();
-            case SLF4j: return new Slf4jLogger();
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
+++ b/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
@@ -65,7 +65,7 @@ public @interface FeignClient {
      * in certain way. The encoder bean class must implement the class feign.codec.Encoder.
      * 
      * Note: 
-     * 1) exclusive with attribute 'encoderBean'
+     * 1) exclusive with attribute 'encoder'
      * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
      * 
      * @return encoder bean for the specified Feign client interface
@@ -73,11 +73,11 @@ public @interface FeignClient {
     String encoderBean() default "";
 
     /**
-     * Encoder bean name for the specified Feign client interface, to decode parameters
+     * Decoder bean name for the specified Feign client interface, to decode parameters
      * in certain way. The decoder bean class must implement the class feign.codec.Decoder.
      * 
      * Note:
-     * 1) exclusive with attribute 'decoderBean'
+     * 1) exclusive with attribute 'decoder'
      * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
      * 
      * @return decoder bean for the specified Feign client interface

--- a/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
+++ b/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
@@ -39,8 +39,49 @@ public @interface FeignClient {
     /**
      * Encoder class for the specified Feign client interface, to encode parameters
      * in certain way. The encoder class must implement the class feign.codec.Encoder.
+     * 
+     * Note: 
+     * 1) exclusive with attribute 'encoderBean'
+     * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
+     * 
      * @return encoder class for the specified Feign client interface
      */
     Class<?> encoder() default void.class;
+
+    /**
+     * Decoder class for the specified Feign client interface, to decode parameters
+     * in certain way. The decoder class must implement the class feign.codec.Decoder.
+     * 
+     * Note:
+     * 1) exclusive with attribute 'decoderBean'
+     * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
+     * 
+     * @return decoder class for the specified Feign client interface
+     */
+    Class<?> decoder() default void.class;
+
+    /**
+     * Encoder bean name for the specified Feign client interface, to encode parameters
+     * in certain way. The encoder bean class must implement the class feign.codec.Encoder.
+     * 
+     * Note: 
+     * 1) exclusive with attribute 'encoderBean'
+     * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
+     * 
+     * @return encoder bean for the specified Feign client interface
+     */
+    String encoderBean() default "";
+
+    /**
+     * Encoder bean name for the specified Feign client interface, to decode parameters
+     * in certain way. The decoder bean class must implement the class feign.codec.Decoder.
+     * 
+     * Note:
+     * 1) exclusive with attribute 'decoderBean'
+     * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
+     * 
+     * @return decoder bean for the specified Feign client interface
+     */
+    String decoderBean() default "";
 
 }

--- a/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
+++ b/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
@@ -43,8 +43,6 @@ public @interface FeignClient {
      * Note: 
      * 1) exclusive with attribute 'encoderBean'
      * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
-     * 
-     * @return encoder class for the specified Feign client interface
      */
     Class<?> encoder() default void.class;
 
@@ -55,8 +53,6 @@ public @interface FeignClient {
      * Note:
      * 1) exclusive with attribute 'decoderBean'
      * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
-     * 
-     * @return decoder class for the specified Feign client interface
      */
     Class<?> decoder() default void.class;
 
@@ -67,8 +63,6 @@ public @interface FeignClient {
      * Note: 
      * 1) exclusive with attribute 'encoder'
      * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
-     * 
-     * @return encoder bean for the specified Feign client interface
      */
     String encoderBean() default "";
 
@@ -79,8 +73,6 @@ public @interface FeignClient {
      * Note:
      * 1) exclusive with attribute 'decoder'
      * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
-     * 
-     * @return decoder bean for the specified Feign client interface
      */
     String decoderBean() default "";
 
@@ -91,8 +83,6 @@ public @interface FeignClient {
      * Note:
      * 1) exclusive with attribute 'errorDecoder'
      * 2) if specified, override FeignClientsProperties.defaultErrorDecoderClass/defaultErrorDecoderBean
-     * 
-     * @return error decoder bean for the specified Feign client interface
      */
     String errorDecoderBean() default "";
 
@@ -103,8 +93,6 @@ public @interface FeignClient {
      * Note:
      * 1) exclusive with attribute 'errorDecoderBean'
      * 2) if specified, override FeignClientsProperties.defaultErrorDecoderClass/defaultErrorDecoderBean
-     * 
-     * @return error decoder class for the specified Feign client interface
      */
     Class<?> errorDecoder() default void.class;
 
@@ -115,8 +103,6 @@ public @interface FeignClient {
      * Note:
      * 1) exclusive with attribute 'clientBean'
      * 2) if specified, override FeignClientsProperties.defaultClientClass/defaultClientBean
-     * 
-     * @return client class for the specified Feign client interface
      */
     Class<?> client() default void.class;
 
@@ -127,8 +113,6 @@ public @interface FeignClient {
      * Note: 
      * 1) exclusive with attribute 'client'
      * 2) if specified, override FeignClientsProperties.defaultClientClass/defaulClientBean
-     * 
-     * @return client bean for the specified Feign client interface
      */
     String clientBean() default "";
 

--- a/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
+++ b/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
@@ -39,80 +39,64 @@ public @interface FeignClient {
     /**
      * Encoder class for the specified Feign client interface, to encode parameters
      * in certain way. The encoder class must implement the class feign.codec.Encoder.
-     * 
-     * Note: 
-     * 1) exclusive with attribute 'encoderBean'
-     * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
+     *
+     * Exclusive with attribute 'encoderBean'
      */
     Class<?> encoder() default void.class;
 
     /**
      * Decoder class for the specified Feign client interface, to decode parameters
      * in certain way. The decoder class must implement the class feign.codec.Decoder.
-     * 
-     * Note:
-     * 1) exclusive with attribute 'decoderBean'
-     * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
+     *
+     * Exclusive with attribute 'decoderBean'
      */
     Class<?> decoder() default void.class;
 
     /**
      * Encoder bean name for the specified Feign client interface, to encode parameters
      * in certain way. The encoder bean class must implement the class feign.codec.Encoder.
-     * 
-     * Note: 
-     * 1) exclusive with attribute 'encoder'
-     * 2) if specified, override FeignClientsProperties.defaultEncoderClass/defaultEncoderBean
+     *
+     * Exclusive with attribute 'encoder'
      */
     String encoderBean() default "";
 
     /**
      * Decoder bean name for the specified Feign client interface, to decode parameters
      * in certain way. The decoder bean class must implement the class feign.codec.Decoder.
-     * 
-     * Note:
-     * 1) exclusive with attribute 'decoder'
-     * 2) if specified, override FeignClientsProperties.defaultDecoderClass/defaultDecoderBean
+     *
+     * Exclusive with attribute 'decoder'
      */
     String decoderBean() default "";
 
     /**
      * Error decoder bean name for the specified Feign client interface, to decode error
      * in certain way. The error decoder bean class must implement the class feign.codec.ErrorDecoder.
-     * 
-     * Note:
-     * 1) exclusive with attribute 'errorDecoder'
-     * 2) if specified, override FeignClientsProperties.defaultErrorDecoderClass/defaultErrorDecoderBean
+     *
+     * Exclusive with attribute 'errorDecoder'
      */
     String errorDecoderBean() default "";
 
     /**
      * Error decoder class for the specified Feign client interface, to decode error
      * in certain way. The error decoder class must implement the class feign.codec.ErrorDecoder.
-     * 
-     * Note:
-     * 1) exclusive with attribute 'errorDecoderBean'
-     * 2) if specified, override FeignClientsProperties.defaultErrorDecoderClass/defaultErrorDecoderBean
+     *
+     * Exclusive with attribute 'errorDecoderBean'
      */
     Class<?> errorDecoder() default void.class;
 
     /**
-     * http client class for the specified Feign client interface. 
+     * http client class for the specified Feign client interface.
      * The client class must implement the class feign.Client.
-     * 
-     * Note:
-     * 1) exclusive with attribute 'clientBean'
-     * 2) if specified, override FeignClientsProperties.defaultClientClass/defaultClientBean
+     *
+     * Exclusive with attribute 'clientBean'
      */
     Class<?> client() default void.class;
 
     /**
-     * http client bean name for the specified Feign client interface. 
+     * http client bean name for the specified Feign client interface.
      * The client bean class must implement the class feign.Client.
-     * 
-     * Note: 
-     * 1) exclusive with attribute 'client'
-     * 2) if specified, override FeignClientsProperties.defaultClientClass/defaulClientBean
+     *
+     * Exclusive with attribute 'client'
      */
     String clientBean() default "";
 

--- a/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
+++ b/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
@@ -108,4 +108,28 @@ public @interface FeignClient {
      */
     Class<?> errorDecoder() default void.class;
 
+    /**
+     * http client class for the specified Feign client interface. 
+     * The client class must implement the class feign.Client.
+     * 
+     * Note:
+     * 1) exclusive with attribute 'clientBean'
+     * 2) if specified, override FeignClientsProperties.defaultClientClass/defaultClientBean
+     * 
+     * @return client class for the specified Feign client interface
+     */
+    Class<?> client() default void.class;
+
+    /**
+     * http client bean name for the specified Feign client interface. 
+     * The client bean class must implement the class feign.Client.
+     * 
+     * Note: 
+     * 1) exclusive with attribute 'client'
+     * 2) if specified, override FeignClientsProperties.defaultClientClass/defaulClientBean
+     * 
+     * @return client bean for the specified Feign client interface
+     */
+    String clientBean() default "";
+
 }

--- a/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
+++ b/src/main/java/com/github/ethancommitpush/feign/annotation/FeignClient.java
@@ -84,4 +84,28 @@ public @interface FeignClient {
      */
     String decoderBean() default "";
 
+    /**
+     * Error decoder bean name for the specified Feign client interface, to decode error
+     * in certain way. The error decoder bean class must implement the class feign.codec.ErrorDecoder.
+     * 
+     * Note:
+     * 1) exclusive with attribute 'errorDecoder'
+     * 2) if specified, override FeignClientsProperties.defaultErrorDecoderClass/defaultErrorDecoderBean
+     * 
+     * @return error decoder bean for the specified Feign client interface
+     */
+    String errorDecoderBean() default "";
+
+    /**
+     * Error decoder class for the specified Feign client interface, to decode error
+     * in certain way. The error decoder class must implement the class feign.codec.ErrorDecoder.
+     * 
+     * Note:
+     * 1) exclusive with attribute 'errorDecoderBean'
+     * 2) if specified, override FeignClientsProperties.defaultErrorDecoderClass/defaultErrorDecoderBean
+     * 
+     * @return error decoder class for the specified Feign client interface
+     */
+    Class<?> errorDecoder() default void.class;
+
 }

--- a/src/test/java/com/github/ethancommitpush/feign/FeignClientsFactoryTest.java
+++ b/src/test/java/com/github/ethancommitpush/feign/FeignClientsFactoryTest.java
@@ -78,7 +78,7 @@ public class FeignClientsFactoryTest {
         this.attributes = new HashMap<String, Object>();
         this.target.setAttributes(this.attributes);
 
-        this.properties.setLoggerKind(FeignLoggerKind.NO_OP);
+        this.properties.setLoggerType(FeignLoggerType.NO_OP);
         this.target.setProperties(this.properties);
     }
 
@@ -90,7 +90,7 @@ public class FeignClientsFactoryTest {
         when(this.environment.resolvePlaceholders("http://test")).thenReturn("http://test");
 
         // TODO: verify how codec/client is invoked
-        
+
         Object actual = this.target.getObject();
         Assert.assertNotNull(actual);
         Assert.assertTrue(actual instanceof TargetInterface);
@@ -238,7 +238,7 @@ public class FeignClientsFactoryTest {
     }
 
     @Test
-    public void test_resolveClient_withAttribute_class() {        
+    public void test_resolveClient_withAttribute_class() {
         this.attributes.put("client", MyClient.class);
 
         Client actual = this.target.resolveClient();

--- a/src/test/java/com/github/ethancommitpush/feign/FeignClientsFactoryTest.java
+++ b/src/test/java/com/github/ethancommitpush/feign/FeignClientsFactoryTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.ethancommitpush.feign;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.Assert;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.ethancommitpush.feign.decoder.CustomErrorDecoder;
+import com.github.ethancommitpush.feign.example.TargetInterface;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.core.env.Environment;
+
+import feign.FeignException;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.codec.DecodeException;
+import feign.codec.Decoder;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+
+public class FeignClientsFactoryTest {
+
+    @Mock
+    private BeanFactory beanFactory;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private Encoder feignEncoder;
+
+    @Mock
+    private Decoder feignDecoder;
+
+    @Mock
+    private ErrorDecoder feignErrorDecoder;
+
+    private FeignClientsProperties properties = new FeignClientsProperties();
+
+    @InjectMocks
+    FeignClientsFactory<TargetInterface> target;
+
+    Map<String, Object> attributes;
+
+    @Before
+    public void beforeEach() {
+        MockitoAnnotations.initMocks(this);
+
+        this.attributes = new HashMap<String, Object>();
+        this.target.setAttributes(this.attributes);
+
+        this.properties.setLoggerKind(FeignLoggerKind.NO_OP);
+        this.target.setProperties(this.properties);
+    }
+
+    @Test
+    public void test_getObject_happy() throws Exception {
+        this.target.setApiType(TargetInterface.class);
+
+        this.attributes.put("url", "http://test");
+        when(this.environment.resolvePlaceholders("http://test")).thenReturn("http://test");
+        
+        Object actual = this.target.getObject();
+        Assert.assertNotNull(actual);
+        Assert.assertTrue(actual instanceof TargetInterface);
+    }
+
+    @Test
+    public void test_getUrl_happy() {
+        String value = "${postman-echo.domain}";
+        this.attributes.put("url", value);
+        when(this.environment.resolvePlaceholders(value)).thenReturn("https://postman-echo.com");
+
+        String actual = this.target.getUrl();
+        Assert.assertEquals("https://postman-echo.com", actual);
+    }
+
+    static class MyEncoder implements Encoder {
+
+        @Override
+        public void encode(Object object, Type bodyType, RequestTemplate template) throws EncodeException {
+            throw new RuntimeException("should not be here");
+        }
+    }
+
+    @Test
+    public void test_resolveEncoder_withDefaultOne() {
+        Encoder actual = this.target.resolveEncoder();
+        Assert.assertSame(this.feignEncoder, actual);
+    }
+
+    @Test
+    public void test_resolveEncoder_withAttribute_bean() {
+        Encoder expected = new MyEncoder();
+
+        this.attributes.put("encoderBean", "myEncoderBean");
+        when(this.beanFactory.getBean("myEncoderBean", Encoder.class)).thenReturn(expected);
+
+        Encoder actual = this.target.resolveEncoder();
+        Assert.assertSame(expected, actual);
+    }
+
+    @Test
+    public void test_resolveEncoder_withAttribute_class() {        
+        this.attributes.put("encoder", MyEncoder.class);
+
+        Encoder actual = this.target.resolveEncoder();
+        Assert.assertTrue(actual.getClass() == MyEncoder.class);
+    }
+
+    static class MyDecoder implements Decoder {
+
+        @Override
+        public Object decode(Response response, Type type) throws IOException, DecodeException, FeignException {
+            throw new RuntimeException("should not be here");
+        }
+    }
+
+    @Test
+    public void test_resolveDecoder_withDefaultOne() {
+        Decoder actual = this.target.resolveDecoder();
+        Assert.assertSame(this.feignDecoder, actual);
+    }
+
+    @Test
+    public void test_resolveDecoder_withAttribute_bean() {
+        Decoder expected = new MyDecoder();
+
+        this.attributes.put("decoderBean", "myDecoderBean");
+        when(this.beanFactory.getBean("myDecoderBean", Decoder.class)).thenReturn(expected);
+
+        Decoder actual = this.target.resolveDecoder();
+        Assert.assertSame(expected, actual);
+    }
+
+    @Test
+    public void test_resolveDecoder_withAttribute_class() {        
+        this.attributes.put("decoder", MyDecoder.class);
+
+        Decoder actual = this.target.resolveDecoder();
+        Assert.assertTrue(actual.getClass() == MyDecoder.class);
+    }
+
+    static class MyErrorDecoder extends CustomErrorDecoder {}
+
+    @Test
+    public void test_resolveErrorDecoder_withDefaultOne() {
+        ErrorDecoder actual = this.target.resolveErrorDecoder();
+        Assert.assertSame(this.feignErrorDecoder, actual);
+    }
+
+    @Test
+    public void test_resolveErrorDecoder_withAttribute_bean() {
+        ErrorDecoder expected = new CustomErrorDecoder();
+        
+        this.attributes.put("errorDecoderBean", "myErrorDecoderBean");
+        when(this.beanFactory.getBean("myErrorDecoderBean", ErrorDecoder.class)).thenReturn(expected);
+        
+        ErrorDecoder actual = this.target.resolveErrorDecoder();
+        Assert.assertSame(expected, actual);
+    }
+
+    @Test
+    public void test_resolveErrorDecoder_withAttribute_class() {        
+        this.attributes.put("errorDecoder", MyErrorDecoder.class);
+
+        ErrorDecoder actual = this.target.resolveErrorDecoder();
+        Assert.assertTrue(actual.getClass() == MyErrorDecoder.class);
+    }
+
+    @Test
+    public void test_resolveAttribute_placeHolder() {
+        String value = "${test.ok}";
+        when(this.environment.resolvePlaceholders(value)).thenReturn("got");
+
+        String actual = this.target.resolveAttribute(value);
+        Assert.assertEquals("got", actual);
+        
+        when(this.environment.resolvePlaceholders(any())).thenReturn(value);
+        Assert.assertEquals(value, this.target.resolveAttribute(value));
+    }
+
+}

--- a/src/test/java/com/github/ethancommitpush/feign/FeignClientsFactoryTest.java
+++ b/src/test/java/com/github/ethancommitpush/feign/FeignClientsFactoryTest.java
@@ -89,6 +89,8 @@ public class FeignClientsFactoryTest {
         this.attributes.put("url", "http://test");
         when(this.environment.resolvePlaceholders("http://test")).thenReturn("http://test");
 
+        // TODO: verify how codec/client is invoked
+        
         Object actual = this.target.getObject();
         Assert.assertNotNull(actual);
         Assert.assertTrue(actual instanceof TargetInterface);

--- a/src/test/java/com/github/ethancommitpush/feign/FeignConfigurationUtilsTest.java
+++ b/src/test/java/com/github/ethancommitpush/feign/FeignConfigurationUtilsTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.ethancommitpush.feign;
+
+import org.junit.Test;
+import org.junit.Assert;
+import static org.mockito.Mockito.*;
+import org.springframework.beans.factory.BeanFactory;
+
+public class FeignConfigurationUtilsTest {
+    
+    static interface TargetInterface {
+
+    }
+
+    static class TargetClassOK implements TargetInterface {
+
+    }
+
+    static class TargetClassWrong implements TargetInterface {
+        TargetClassWrong() {
+            throw new RuntimeException("mock error");
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_resolveOverrideableBean_bothBeanNameAndClass() {
+        BeanFactory bf = mock(BeanFactory.class);
+        
+        FeignConfigurationUtils.resolveOverrideableBean(TargetInterface.class, 
+            bf, "target", TargetClassOK.class);
+    }
+
+    @Test
+    public void test_resolveOverrideableBean_withBeanName() {
+        TargetClassOK expected = new TargetClassOK();
+
+        BeanFactory bf = mock(BeanFactory.class);
+        when(bf.getBean("target", TargetInterface.class)).thenReturn(expected);
+        
+        TargetInterface actual = FeignConfigurationUtils.resolveOverrideableBean(TargetInterface.class, 
+            bf, "target", null);
+        Assert.assertSame(expected, actual);
+    }
+
+    @Test
+    public void test_resolveOverrideableBean_withClass() {
+        BeanFactory bf = mock(BeanFactory.class);
+        
+        TargetInterface actual = FeignConfigurationUtils.resolveOverrideableBean(TargetInterface.class, 
+            bf, "", TargetClassOK.class);
+        Assert.assertTrue(actual instanceof TargetClassOK);
+
+        verify(bf, never()).getBean(anyString(), (Class<?>)any());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_resolveOverrideableBean_wrongClass() {
+        BeanFactory bf = mock(BeanFactory.class);
+        
+        FeignConfigurationUtils.resolveOverrideableBean(TargetInterface.class, 
+            bf, "", TargetClassWrong.class);
+    }
+
+
+}

--- a/src/test/java/com/github/ethancommitpush/feign/FeignConfigurationUtilsTest.java
+++ b/src/test/java/com/github/ethancommitpush/feign/FeignConfigurationUtilsTest.java
@@ -16,23 +16,14 @@ package com.github.ethancommitpush.feign;
 import org.junit.Test;
 import org.junit.Assert;
 import static org.mockito.Mockito.*;
+
+import com.github.ethancommitpush.feign.example.TargetClassOK;
+import com.github.ethancommitpush.feign.example.TargetClassWrong;
+import com.github.ethancommitpush.feign.example.TargetInterface;
+
 import org.springframework.beans.factory.BeanFactory;
 
 public class FeignConfigurationUtilsTest {
-    
-    static interface TargetInterface {
-
-    }
-
-    static class TargetClassOK implements TargetInterface {
-
-    }
-
-    static class TargetClassWrong implements TargetInterface {
-        TargetClassWrong() {
-            throw new RuntimeException("mock error");
-        }
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_resolveOverrideableBean_bothBeanNameAndClass() {
@@ -40,6 +31,18 @@ public class FeignConfigurationUtilsTest {
         
         FeignConfigurationUtils.resolveOverrideableBean(TargetInterface.class, 
             bf, "target", TargetClassOK.class);
+    }
+
+    @Test
+    public void test_resolveOverrideableBean_withBeanNameAndVoidClass() {
+        TargetClassOK expected = new TargetClassOK();
+
+        BeanFactory bf = mock(BeanFactory.class);
+        when(bf.getBean("target", TargetInterface.class)).thenReturn(expected);
+        
+        TargetInterface actual = FeignConfigurationUtils.resolveOverrideableBean(TargetInterface.class, 
+            bf, "target", void.class);
+        Assert.assertSame(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/github/ethancommitpush/feign/example/TargetClassOK.java
+++ b/src/test/java/com/github/ethancommitpush/feign/example/TargetClassOK.java
@@ -1,0 +1,6 @@
+package com.github.ethancommitpush.feign.example;
+
+public class TargetClassOK implements TargetInterface {
+
+    
+}

--- a/src/test/java/com/github/ethancommitpush/feign/example/TargetClassWrong.java
+++ b/src/test/java/com/github/ethancommitpush/feign/example/TargetClassWrong.java
@@ -1,0 +1,8 @@
+package com.github.ethancommitpush.feign.example;
+
+public class TargetClassWrong implements TargetInterface {
+
+    public TargetClassWrong() {
+        throw new RuntimeException("mock error");
+    }
+}

--- a/src/test/java/com/github/ethancommitpush/feign/example/TargetInterface.java
+++ b/src/test/java/com/github/ethancommitpush/feign/example/TargetInterface.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020 Yisin Lin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.ethancommitpush.feign.example;
+
+public interface TargetInterface {
+
+}


### PR DESCRIPTION
1) Move feign client builder method from registrar to separated factory bean
2) Customization style:
    - default properties are in FeignClientsProperties
    - FeignClient annotation could overrides default properties, if specified
    - for each customizable component, customization is done via a pair of class/bean name which is exclusive.
3) add unit test cases.